### PR TITLE
search symlinks

### DIFF
--- a/create_es_bulk_json.py
+++ b/create_es_bulk_json.py
@@ -3,8 +3,8 @@ import sys, json, subprocess
 
 # SSH into a remote server and find war files under certain directories
 def get_file_names(instance):
-    path = "*/%s/*/current/dist/*[[:digit:]].war" % instance
-    ssh = subprocess.Popen(['ssh', '-l', xe_user, xe_host, 'find', banner_home, '-type f -wholename', path, '-printf "%f\n"'],
+    path = "*/%s/*/current/dist/*.war" % instance
+    ssh = subprocess.Popen(['ssh', '-l', xe_user, xe_host, 'find', banner_home, '-type l -wholename', path, '-exec readlink {} \;'],
                            shell=False,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE)


### PR DESCRIPTION
since the original directory structure being searched contains an archive folder, and sometimes there can be multiple xe war files in one directory, it made more sense to get what file the symlink is pointing to since the symlink is what's used for deployment