### PR TITLE
CO-1214: Replace Elasticsearch with JSON file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Get XE Versions for ES (Elastic Search)
+# Get XE Applications
 
-This repository contains a script that uses SSH to get the names of war files on a remote server,
-parses their names, versions, and instances, then finally dumps that data to a JSON file ready
-to be bulk uploaded to Elastic Search.
+This repository contains a Python 3 script that uses SSH to get the names of war files on a remote server,
+parses their names, versions, and instances, then finally dumps that data to a JSON file. This file
+is then used by the meta-xe API.
 
 ## Instructions
-1. Copy configuration_example.json as configuration.json and modify as needed. 
-banner_home is where the script will be searching from.
+1. Copy configuration_example.json to configuration.json and modify as needed. `"banner_home"` is
+where the script will be searching from.
+
 2. Run the script passing configuration.json as an argument:
 ```
-python ./create_es_bulk_json.py -i configuration.json
+$ python3 create_es_bulk_json.py -i configuration.json
 ```
-3. xe_apps.json will be created in the same directory as create_es_bulk_json.py
-4. Post xe_apps.json to Elastic Search:
-```
-curl -s -XPOST localhost:9200/xe/apps/_bulk --data-binary "@xe_apps.json"
-```
-Note: xe_apps.json will be overwritten when running create_es_bulk_json.py
+
+3. `xe_apps.json` will be created in the same directory as `create_es_bulk_json.py`
+
+#### Note:
+`xe_apps.json` will be overwritten when running `create_es_bulk_json.py`

--- a/README.md
+++ b/README.md
@@ -15,5 +15,31 @@ $ python3 create_es_bulk_json.py -i configuration.json
 
 3. `xe_apps.json` will be created in the same directory as `create_es_bulk_json.py`
 
+### JSON File Example
+```json
+{
+  "app1": {
+    "versions": [
+      {
+        "instance": "devl",
+        "version": "2.0"
+      },
+      {
+        "instance": "prod",
+        "version": "1.0"
+      }
+    ]
+  },
+  "app2": {
+    "versions": [
+      {
+        "instance": "devl",
+        "version": "1.0"
+      }
+    ]
+  }
+}
+```
+
 #### Note:
 `xe_apps.json` will be overwritten when running `create_es_bulk_json.py`

--- a/create_es_bulk_json.py
+++ b/create_es_bulk_json.py
@@ -1,24 +1,31 @@
 # coding=utf-8
-import sys, json, subprocess
+import argparse
+import json
+import subprocess
+import sys
+
 
 # SSH into a remote server and find war files under certain directories
 def get_file_names(instance):
-    path = "*/%s/*/current/dist/*.war" % instance
-    ssh = subprocess.Popen(['ssh', '-l', xe_user, xe_host, 'find', banner_home, '-type l -wholename', path, '-exec readlink {} \;'],
-                           shell=False,
-                           stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE)
+    path = f"*/{instance}/*/current/dist/*.war"
+    command = [
+        'ssh', '-l', xe_user, xe_host, 'find', banner_home,
+        '-type l -wholename', path, '-exec readlink {} \;'
+    ]
+    ssh = subprocess.Popen(
+        command, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     result = ssh.stdout.readlines()
     # If we didn't get any files, something's wrong
-    if result == []:
+    if not result:
         error = ssh.stderr.readlines()
-        print >> sys.stderr, "ERROR: %s" % error
-        sys.exit(1)
+        sys.exit(f"ERROR: {error}")
 
-    return result    
+    return result
+
 
 # Parse the whole filename into the application name and version.
-def parse_file_names(instance, xe_apps):
+def parse_file_names(instance):
     file_names = get_file_names(instance)
 
     for file in file_names:
@@ -33,39 +40,26 @@ def parse_file_names(instance, xe_apps):
         else:
             xe_apps[app] = {"applicationName": app, "versions": [version_dict]}
 
-# Call above methods to get a dict containing all the apps, then write to a json file
-def write_apps_to_file():
-    xe_apps = {}
 
-    # For each deployed environment, do a search for war files in the respective directories
+# Call above methods to get a dict containing all the apps, then write to a
+# json file
+def write_apps_to_file():
+
+    # For each deployed environment, do a search for war files in the
+    # respective directories
     for instance in environments:
-        parse_file_names(instance, xe_apps)
+        parse_file_names(instance)
 
     # Create json file, overwrite if it exists.
     with open('xe_apps.json', 'w') as xe_app_file:
-        # Create two lines in the json file for each app, one for id, and one for data
-        for app in xe_apps:
-            xe_app_file.write(json.dumps({"index":{"_id":xe_apps[app]['applicationName']}}))
-            xe_app_file.write('\n')
-            xe_app_file.write(json.dumps(xe_apps[app]))
-            xe_app_file.write('\n')
+        json.dump(xe_apps, xe_app_file)
+
 
 if __name__ == '__main__':
-    options_tpl = ('-i', 'config_path')
-    del_list = []
-    
-    for i,config_path in enumerate(sys.argv):
-        if config_path in options_tpl:
-            del_list.append(i)
-            del_list.append(i+1)
-
-    del_list.reverse()
-
-    for i in del_list:
-        del sys.argv[i]
-
-    config_data_file = open(config_path)
-    config_json = json.load(config_data_file)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", help="path to input file", dest="input_file")
+    namespace = parser.parse_args()
+    config_json = json.load(open(namespace.input_file))
 
     xe_user = config_json["xe_user"]
     xe_host = config_json["xe_host"]


### PR DESCRIPTION
Since Elasticsearch isn't being used for the meta-xe-api anymore, the
output will just be a basic JSON file.

Changes were made to simplify the code and adhere it to PEP8.

Currently, the Python script is still called `create_es_bulk_json.py` just for the sake of being to easily see the changes I made. I intend to change this to something like `get_xe_applications.py` or `create_xe_json.py` after my changes are approved.